### PR TITLE
Remove depth limit and fix tactical module evaluation

### DIFF
--- a/test_full_agent.py
+++ b/test_full_agent.py
@@ -8,7 +8,7 @@ print("Initial Board:")
 print(board)
 
 for i in range(20):
-    move = agent.act(board)
+    move, diag = agent.act(board)
     print(f"\nMove {i+1}: {move}")
     board.push(move)
     print(board)

--- a/test_tactical_agent.py
+++ b/test_tactical_agent.py
@@ -4,16 +4,17 @@ from mcca.modules.tactical_module import TacticalModule
 # Set up a starting chess board
 board = chess.Board()
 
-# Initialize the tactical module (uses Stockfish)
-tactical = TacticalModule(depth=10)
+# Initialize the tactical module (uses Stockfish with no depth limit)
+tactical = TacticalModule()
 
 # Show the current board
 print("Initial position:")
 print(board)
 
-# Get recommended move
-move = tactical.act(board)
+# Get recommended move and diagnostics
+move, diag = tactical.act(board)
 print("\nTactical Module suggests:", move)
+print("Diagnostics:", diag)
 
 # Play the move on the board
 board.push(move)


### PR DESCRIPTION
## Summary
- allow `TacticalModule` to run without a depth limit
- added configurable time limit so engine doesn't hang
- fix `evaluate` return value
- update sample scripts for new API

## Testing
- `python test_tactical_agent.py`
- `python test_full_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_685a72ad714483229928b8158d5c00cc