### PR TITLE
Improve tactical regime detection and response

### DIFF
--- a/mcca/meta_policy_controller.py
+++ b/mcca/meta_policy_controller.py
@@ -31,6 +31,7 @@ diagnostics  : {
 from __future__ import annotations
 from typing import Dict, Any, Tuple, List
 import math
+from mcca.regime_detector import RegimeDetector
 
 
 class MetaPolicyController:
@@ -60,6 +61,24 @@ class MetaPolicyController:
         opponent_type: str,
         module_trace: Dict[str, Any] | None = None
     ) -> Tuple[Dict[str, float], Dict[str, Any]]:
+        # check for immediate tactical danger override
+        checks, attackers = RegimeDetector._tactical_danger_zone(board)
+        if (board.is_check() or checks >= 2 or attackers >= 3) and regime == "tactical":
+            w = {
+                "tactical": 0.85,
+                "shaping": 0.05,
+                "positional": 0.05,
+                "deception": 0.05,
+            }
+            diag = {
+                "boost": [],
+                "suppress": [],
+                "reflex": True,
+                "collapse_penalty": False,
+                "mismatch_adjust": False,
+                "raw": w.copy(),
+            }
+            return w, diag
 
         # 1. ---- Start from base ------------------------------------ #
         weights = dict(self._BASE.get(regime, self._BASE["tactical"]))

--- a/mcca/modules/deception_module.py
+++ b/mcca/modules/deception_module.py
@@ -1,6 +1,7 @@
 # File: mcca/modules/deception_module.py
 import random
 import chess
+from mcca.regime_detector import RegimeDetector
 
 
 class DeceptionModule:
@@ -32,6 +33,11 @@ class DeceptionModule:
         legal = list(board.legal_moves)
         if not legal:
             return None, {"suppress": True, "reason": "no legal moves"}
+
+        checks, attackers = RegimeDetector._tactical_danger_zone(board)
+        if board.is_check() or checks >= 2 or attackers >= 3:
+            fallback = random.choice(legal)
+            return fallback, {"suppress": True, "reason": "danger_zone", "risk": 1.0}
 
         scored = []
         for mv in legal:


### PR DESCRIPTION
## Summary
- detect tactical danger from legal checks and king attackers in `RegimeDetector`
- override to tactical when danger zone detected
- adjust `MetaPolicyController` to hardcode weights in active danger
- avoid deception moves in heavy tactical pressure
- record tactical evaluations in agent history and log regime drift

## Testing
- `python -m py_compile mcca/*.py mcca/modules/*.py`
- `python test_full_agent.py` *(fails: FileNotFoundError: '/usr/games/stockfish')*
- `python test_tactical_agent.py` *(fails: FileNotFoundError: '/usr/games/stockfish')*

------
https://chatgpt.com/codex/tasks/task_e_685a78752bb4832295aeb2a3f2900550